### PR TITLE
[Bugfix] Use current env instead of primary

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,6 @@ With the plugin, after updating the Grandparent record:
     *  Child: /grandparent-new/parent/child
 
 ## Changelog
+- 0.5.0: Bugfix: Now correctly works in sandbox environments. It was previously always using the primary env's data.  
 - 0.3.1: Dependency updates and bug fixes. Migrated to newer plugin SDK version.
 - 0.3.0: Previous release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-plugin-tree-like-slugs",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": false,
   "homepage": "https://github.com/marcelofinamorvieira/datocms-plugin-tree-like-slugs",
   "description": "A plugin that makes it so the slugs in models with Hierarchical Sorting (tree-like models) are passed down to child records",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -70,7 +70,8 @@ connect({
       createOrUpdateItemPayload.data.relationships!.item_type!.data.id,
       createOrUpdateItemPayload.data.id!,
       updatedFieldKey,
-      createOrUpdateItemPayload.data.attributes![updatedFieldKey] as string
+      createOrUpdateItemPayload.data.attributes![updatedFieldKey] as string,
+      ctx.environment
     );
 
     return true;

--- a/src/utils/updateAllChildrenSlugs.ts
+++ b/src/utils/updateAllChildrenSlugs.ts
@@ -1,14 +1,16 @@
 import { buildClient } from "@datocms/cma-client-browser";
 
 export default async function updateAllChildrenSlugs(
-  apiToken: string,
-  modelID: string,
-  parentID: string,
-  slugFieldKey: string,
-  updatedSlug: string
+    apiToken: string,
+    modelID: string,
+    parentID: string,
+    slugFieldKey: string,
+    updatedSlug: string,
+    env: string,
 ) {
   const client = buildClient({
     apiToken,
+    environment: env
   });
 
   const records = await client.items.list({
@@ -27,17 +29,18 @@ export default async function updateAllChildrenSlugs(
       const destructuredOldSlug = (record[slugFieldKey] as string).split("/");
       await client.items.update(record.id, {
         [slugFieldKey]:
-          updatedSlug +
-          "/" +
-          destructuredOldSlug[destructuredOldSlug.length - 1],
+            updatedSlug +
+            "/" +
+            destructuredOldSlug[destructuredOldSlug.length - 1],
       });
 
       await updateAllChildrenSlugs(
-        apiToken,
-        modelID,
-        record.id,
-        slugFieldKey,
-        updatedSlug + "/" + destructuredOldSlug[destructuredOldSlug.length - 1]
+          apiToken,
+          modelID,
+          record.id,
+          slugFieldKey,
+          updatedSlug + "/" + destructuredOldSlug[destructuredOldSlug.length - 1],
+          env
       );
     }
   }


### PR DESCRIPTION
The plugin was accidentally fetching from the primary env even when in a sandbox. This adds `ctx.environment` as a param to the `updateAllChildrenSlugs()` function.